### PR TITLE
Don't use nightly feature unnecessarily

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(bufreader_seek_relative)]
-
 use std::fs::File;
 use std::io::BufReader;
 use std::io::Read;


### PR DESCRIPTION
## Before this PR

[seek_relative](https://doc.rust-lang.org/std/io/struct.BufReader.html#method.seek_relative) isn't even used right now, but the feature is still declared, meaning you need to use nightly to compile against this project.

## After this PR

Nightly feature not required anymore.