### PR TITLE
Various improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ doc = true
 [dependencies]
 byteorder = "1.2"
 pathfinding = "1.1"
-hashbrown = "0.1"
+hashbrown = "0.5"
 
 [profile.bench]
 opt-level = 3

--- a/src/dart.rs
+++ b/src/dart.rs
@@ -168,16 +168,12 @@ impl DartDict {
     }
 }
 
-pub (crate) fn load_mecab_dart_file(arg_magic : u32, mut reader : BufReader<File>) -> Result<DartDict, &'static str>
+pub (crate) fn load_mecab_dart_file(mut reader : BufReader<File>) -> Result<DartDict, &'static str>
 {
     let dic_file : &mut BufReader<File> = &mut reader;
     // magic
-    let magic = read_u32(dic_file)?;
-    if magic != arg_magic
-    {
-        return Err("not a mecab dic_file dic_file or is a dic_file dic_file of the wrong kind");
-    }
-    
+    seek_rel_4(dic_file)?;
+
     // 0x04
     let version = read_u32(dic_file)?;
     if version != 0x66

--- a/src/dart.rs
+++ b/src/dart.rs
@@ -1,8 +1,6 @@
 use hashbrown::HashMap;
 use hashbrown::HashSet;
 
-use std::fs::File;
-use std::io::BufReader;
 use std::io::BufRead;
 use std::io::Read;
 use std::io::Seek;
@@ -19,7 +17,7 @@ pub (crate) struct Link {
 }
 
 impl Link {
-    pub (crate) fn read<T : Read>(sysdic : &mut BufReader<T>) -> Result<Link, &'static str>
+    pub (crate) fn read<T : Read>(sysdic : &mut T) -> Result<Link, &'static str>
     {
         Ok(Link{base : read_u32(sysdic)?, check : read_u32(sysdic)?})
     }
@@ -107,7 +105,6 @@ fn collect_links_into_map(links : Vec<Link>) -> HashMap<String, DictInfo>
     entries_to_tokens(collection)
 }
 
-#[derive(Debug)]
 pub (crate) struct DartDict {
     pub(crate) dict : HashMap<String, DictInfo>,
     pub(crate) tokens : Vec<FormatToken>,
@@ -116,7 +113,7 @@ pub (crate) struct DartDict {
     pub(crate) right_contexts : u32,
     feature_bytes_location : usize,
     feature_bytes_count : usize,
-    reader : RefCell<BufReader<File>>,
+    reader : RefCell<Box<dyn crate::BufReadSeek>>,
     feature_string_cache : RefCell<HashMap<u32, String>>
 }
 
@@ -168,9 +165,10 @@ impl DartDict {
     }
 }
 
-pub (crate) fn load_mecab_dart_file(mut reader : BufReader<File>) -> Result<DartDict, &'static str>
+pub (crate) fn load_mecab_dart_file<T>(mut reader : T) -> Result<DartDict, &'static str>
+    where T: BufRead + Seek + 'static
 {
-    let dic_file : &mut BufReader<File> = &mut reader;
+    let dic_file = &mut reader;
     // magic
     seek_rel_4(dic_file)?;
 
@@ -251,7 +249,7 @@ pub (crate) fn load_mecab_dart_file(mut reader : BufReader<File>) -> Result<Dart
         right_contexts,
         feature_bytes_location,
         feature_bytes_count : featurebytes as usize,
-        reader : RefCell::new(reader),
+        reader : RefCell::new(Box::new(reader)),
         feature_string_cache : RefCell::new(HashMap::new())
     })
 }

--- a/src/dart.rs
+++ b/src/dart.rs
@@ -210,7 +210,7 @@ pub (crate) fn load_mecab_dart_file(arg_magic : u32, mut reader : BufReader<File
     seek_rel_4(dic_file)?;
     
     let encoding = read_nstr(dic_file, 0x20)?;
-    if encoding != "UTF-8"
+    if encoding.to_lowercase() != "utf-8"
     {
         return Err("only UTF-8 dictionaries are supported. stop using legacy encodings for infrastructure!");
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,8 +241,8 @@ impl Dict {
         mut unkchar : BufReader<File>,
     ) -> Result<Dict, &'static str>
     {
-        let sys_dic = load_mecab_dart_file(0xE1_17_21_81, sysdic)?;
-        let unk_dic = load_mecab_dart_file(0xEF_71_9A_03, unkdic)?;
+        let sys_dic = load_mecab_dart_file(sysdic)?;
+        let unk_dic = load_mecab_dart_file(unkdic)?;
         let unk_data = load_char_bin(&mut unkchar)?;
         
         let left_edges  = read_u16(&mut matrix)?;

--- a/src/unkchar.rs
+++ b/src/unkchar.rs
@@ -1,8 +1,6 @@
 use hashbrown::HashMap;
 
-use std::io::BufReader;
 use std::io::Read;
-use std::io::Seek;
 
 use super::file::*;
 
@@ -126,7 +124,7 @@ impl UnkChar {
     }
 }
 
-pub (crate) fn load_char_bin<T : Read + Seek>(file : &mut BufReader<T>) -> Result<UnkChar, &'static str>
+pub (crate) fn load_char_bin<T : Read>(file : &mut T) -> Result<UnkChar, &'static str>
 {
     let num_types = read_u32(file)?;
     let mut type_names = Vec::new();

--- a/src/unkchar.rs
+++ b/src/unkchar.rs
@@ -161,7 +161,7 @@ mod tests {
         let unkdic = BufReader::new(File::open("data/unk.dic").unwrap());
         let mut unkdef = BufReader::new(File::open("data/char.bin").unwrap());
         
-        dart::load_mecab_dart_file(0xEF_71_9A_03, unkdic).unwrap();
+        dart::load_mecab_dart_file(unkdic).unwrap();
         load_char_bin(&mut unkdef).unwrap();
     }
 }

--- a/src/userdict.rs
+++ b/src/userdict.rs
@@ -1,4 +1,3 @@
-use std::io::BufReader;
 use std::io::BufRead;
 use std::io::Read;
 
@@ -15,7 +14,7 @@ pub (crate) struct UserDict {
 }
 
 impl UserDict {
-    pub (crate) fn load<T : Read>(file : &mut BufReader<T>) -> Result<UserDict, &'static str>
+    pub (crate) fn load<T : Read + BufRead>(file : &mut T) -> Result<UserDict, &'static str>
     {
         let mut dict : HashMap<String, Vec<FormatToken>> = HashMap::new();
         let mut contains_longer = HashSet::new();
@@ -78,6 +77,7 @@ impl UserDict {
 #[cfg(test)]
 mod tests {
     use std::fs::File;
+    use std::io::BufReader;
     use super::*;
     
     #[test]


### PR DESCRIPTION
- I've got rid of the magic bytes check since apparently it's calculated from the dictionary length so it's actually useless as far as magic bytes go. (Well, unless you want to only check for a very specific dictionary?)
- I've made the encoding check case-insensitive (the `naist-jdic` dictionary which I tried to use had it in lowercase)
- I've removed the `File` hardcodes so that it's possible to load the dictionary not only from a file (e.g. so now it should be possible to use [`include_bytes!`](https://doc.rust-lang.org/std/macro.include_bytes.html) to embed the dictionary in the binary itself).
- I've bumped `hashbrown` from 0.1 to 0.5