### PR TITLE
Make it possible to use memory-mapped I/O, improve performance, make the code more multithreading-friendly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ doc = true
 byteorder = "1.2"
 pathfinding = "1.1"
 hashbrown = "0.5"
+memmap = "0.7"
 
 [profile.bench]
 opt-level = 3

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,5 @@
 notmecab-rs is a very basic mecab clone, designed only to do parsing, not training.
 
-notmecab-rs loads everything into memory, so it has higher memory requirements than mecab, which uses memory mapping for most things.
-
 This is meant to be used as a library by other tools such as frequency analyzers. Not directly by people.
 It also only works with UTF-8 dictionaries. (Stop using encodings other than UTF-8 for infrastructural software.)
 
@@ -15,22 +13,21 @@ Get unidic's sys.dic, matrix.bin, unk.dic, and char.bin and put them in data/. T
 
 notmecab performs significantly worse than mecab, but there are many cases where mecab fails to find the lowest-cost string of tokens, so I'm pretty sure that it's just cutting corners somewhere performance sensitive in its code.
 
-There are a couple difficult-to-use caching features designed to improve performance. By default, matrix costs will be cached in a hashmap. You can upload a matrix of connections between the most common connection edge types with ```prepare_fast_matrix_cache```, which is for extremely large dictionaries like modern versions of unidic, or you can load the entire matrix connection cache into memory with ```prepare_full_matrix_cache```, which is for small dictionaries like ipadic. Note that ```prepare_full_matrix_cache``` is actually slower than ```prepare_fast_matrix_cache``` for modern versions of unidic after long periods of pumping text through notmecab, though obviously ```prepare_full_matrix_cache``` is the best option for small dictionaries.
+There are a couple difficult-to-use caching features designed to improve performance. You can upload a matrix of connections between the most common connection edge types with ```prepare_fast_matrix_cache```, which is for extremely large dictionaries like modern versions of unidic, or you can load the entire matrix connection cache into memory with ```prepare_full_matrix_cache```, which is for small dictionaries like ipadic. Note that ```prepare_full_matrix_cache``` is actually slower than ```prepare_fast_matrix_cache``` for modern versions of unidic after long periods of pumping text through notmecab, though obviously ```prepare_full_matrix_cache``` is the best option for small dictionaries.
 
 There are no stability guarantees about the presence or behavior of ```prepare_fast_matrix_cache```, because it's very hacky and if I find a better way to do what it's doing then I'm going to remove it.
 
 # Example (from tests)
 
     // you need to acquire a mecab dictionary and place these files here manually
-    let sysdic = BufReader::new(File::open("data/sys.dic").unwrap());
-    let unkdic = BufReader::new(File::open("data/unk.dic").unwrap());
-    let matrix = BufReader::new(File::open("data/matrix.bin").unwrap());
-    let unkdef = BufReader::new(File::open("data/char.bin").unwrap());
-    
+    let sysdic = Blob::open("data/sys.dic").unwrap();
+    let unkdic = Blob::open("data/unk.dic").unwrap();
+    let matrix = Blob::open("data/matrix.bin").unwrap();
+    let unkdef = Blob::open("data/char.bin").unwrap();
+
     let dict = Dict::load(sysdic, unkdic, matrix, unkdef).unwrap();
 
-    let result = parse(&dict, &"これを持っていけ".to_string()).unwrap();
-
+    let result = parse(&dict, "これを持っていけ").unwrap();
     for token in &result.0
     {
         println!("{}", token.feature);

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -1,0 +1,80 @@
+use std::fs::File;
+use std::io;
+use std::ops::Deref;
+use std::path::Path;
+
+/// A blob of bytes.
+pub struct Blob {
+    _data: Box<dyn AsRef<[u8]> + Sync + Send>,
+    pointer: *const u8,
+    length: usize
+}
+
+unsafe impl Sync for Blob {}
+unsafe impl Send for Blob {}
+
+impl Deref for Blob {
+    type Target = [u8];
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        // Technically we could just dereference the data handle
+        // and grab the reference from there, but that would be
+        // potentially slower as the data is boxed.
+        unsafe {
+            std::slice::from_raw_parts(self.pointer, self.length)
+        }
+    }
+}
+
+impl AsRef<[u8]> for Blob {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        self.deref()
+    }
+}
+
+impl Blob {
+    /// Constructs a new `Blob`. The `data` object will be kept alive until
+    /// the `Blob` is dropped.
+    ///
+    /// # Examples
+    /// ```rust
+    /// # use notmecab::Blob;
+    /// static STATIC_SLICE: &[u8] = &[1, 2, 3];
+    /// let blob_1 = Blob::new(STATIC_SLICE);
+    /// assert_eq!(blob_1.len(), 3);
+    /// assert_eq!(&*blob_1, &[1, 2, 3]);
+    ///
+    /// let vector: Vec<u8> = vec![4, 5];
+    /// let blob_2 = Blob::new(vector);
+    /// assert_eq!(blob_2.len(), 2);
+    /// assert_eq!(&*blob_2, &[4, 5])
+    /// ```
+    pub fn new(data: impl AsRef<[u8]> + Sync + Send + 'static) -> Self {
+        let data = Box::new(data);
+        let slice: &[u8] = (*data).as_ref();
+        let pointer = slice.as_ptr();
+        let length = slice.len();
+        Blob {
+            _data: data,
+            pointer,
+            length
+        }
+    }
+
+    /// Opens a file at a given path and creates a `Blob` from it. Will use `mmap`.
+    pub fn open(path: impl AsRef<Path>) -> io::Result<Self> {
+        let fp = File::open(path)?;
+        Self::from_file(&fp)
+    }
+
+    /// Creates a `Blob` from a `File`. Will use `mmap`.
+    pub fn from_file(fp: &File) -> io::Result<Self> {
+        let mmap = unsafe {
+            memmap::Mmap::map(fp)?
+        };
+
+        Ok(Self::new(mmap))
+    }
+}

--- a/src/dart.rs
+++ b/src/dart.rs
@@ -1,12 +1,10 @@
 use hashbrown::HashMap;
 use hashbrown::HashSet;
 
-use std::io::BufRead;
 use std::io::Cursor;
 use std::io::Read;
 use std::io::Seek;
-
-use std::cell::RefCell;
+use std::ops::Range;
 
 use super::blob::*;
 use super::file::*;
@@ -113,10 +111,8 @@ pub (crate) struct DartDict {
     pub(crate) contains_longer : HashSet<String>,
     pub(crate) left_contexts : u32,
     pub(crate) right_contexts : u32,
-    feature_bytes_location : usize,
-    feature_bytes_count : usize,
-    blob : Blob,
-    feature_string_cache : RefCell<HashMap<u32, String>>
+    feature_bytes_range : Range<usize>,
+    blob : Blob
 }
 
 impl DartDict {
@@ -135,34 +131,30 @@ impl DartDict {
             None
         }
     }
-    pub (crate) fn feature_get(&self, offset : u32) -> Result<String, &'static str>
+    pub (crate) fn feature_get(&self, offset : u32) -> &str
     {
-        if let Some(cached) = self.feature_string_cache.borrow().get(&offset)
-        {
-            return Ok(cached.clone());
-        }
-        if (offset as usize) < self.feature_bytes_count
-        {
-            let mut vec = Vec::new();
-            let mut reader = Cursor::new(&self.blob);
-            reader.seek(std::io::SeekFrom::Start(self.feature_bytes_location as u64 + offset as u64)).unwrap();
-            reader.read_until(0, &mut vec).ok();
-            let ret = read_str_buffer(&vec[..]);
-            if ret.is_ok()
-            {
-                let ret = ret.unwrap();
-                let mut cache = self.feature_string_cache.borrow_mut();
-                cache.insert(offset, ret.clone());
-                Ok(ret)
+        let offset = offset as usize;
+        let feature_blob = &self.blob[self.feature_bytes_range.clone()];
+        let slice = match feature_blob.get(offset..) {
+            Some(slice) => slice,
+            None => {
+                // Out-of-range offset.
+                return "";
             }
-            else
-            {
-                ret
-            }
-        }
-        else
-        {
-            Ok("".to_string())
+        };
+
+        let length = slice.iter().copied().take_while(|&byte| byte != 0).count();
+        let slice = &slice[..length];
+
+        let is_at_char_boundary =
+            slice.is_empty() || (slice[0] as i8) >= -0x40;
+
+        assert!(is_at_char_boundary);
+
+        // This is safe since we checked that the whole feature blob is valid
+        // UTF-8 when we loaded the dictionary.
+        unsafe {
+            std::str::from_utf8_unchecked(slice)
         }
     }
 }
@@ -201,7 +193,7 @@ pub (crate) fn load_mecab_dart_file(blob : Blob) -> Result<DartDict, &'static st
         return Err("dictionary broken: token table stored with number of bytes that is not a multiple of 16");
     }
     // 0x20
-    let featurebytes = read_u32(dic_file)?; // number of bytes used to store the feature string pile
+    let feature_bytes_count = read_u32(dic_file)? as usize; // number of bytes used to store the feature string pile
     seek_rel_4(dic_file)?;
     
     let encoding = read_nstr(dic_file, 0x20)?;
@@ -223,7 +215,17 @@ pub (crate) fn load_mecab_dart_file(blob : Blob) -> Result<DartDict, &'static st
     }
     
     let feature_bytes_location = dic_file.seek(std::io::SeekFrom::Current(0)).unwrap() as usize;
-    
+    let feature_bytes_range = feature_bytes_location..feature_bytes_location + feature_bytes_count;
+    let feature_slice = match blob.get(feature_bytes_range.clone()) {
+        Some(slice) => slice,
+        None => {
+            return Err("dictionary broken: invalid feature bytes range");
+        }
+    };
+    if std::str::from_utf8(feature_slice).is_err() {
+        return Err("dictionary broken: feature blob is not valid UTF-8");
+    }
+
     let dictionary = collect_links_into_map(links);
     
     let mut contains_longer = HashSet::new();
@@ -248,9 +250,7 @@ pub (crate) fn load_mecab_dart_file(blob : Blob) -> Result<DartDict, &'static st
         contains_longer,
         left_contexts,
         right_contexts,
-        feature_bytes_location,
-        feature_bytes_count : featurebytes as usize,
-        blob,
-        feature_string_cache : RefCell::new(HashMap::new())
+        feature_bytes_range,
+        blob
     })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,6 @@ use std::io::Cursor;
 use std::io::Read;
 use std::io::Seek;
 
-use std::cell::RefCell;
-
 use std::str;
 
 extern crate pathfinding;
@@ -214,7 +212,7 @@ pub struct Dict {
     left_edges : u16,
     right_edges : u16,
     
-    matrix : RefCell<EdgeInfo>
+    matrix : EdgeInfo
 }
 
 impl Dict {
@@ -257,7 +255,7 @@ impl Dict {
           left_edges,
           right_edges,
           
-          matrix : RefCell::new(EdgeInfo::new(matrix))
+          matrix : EdgeInfo::new(matrix)
         })
     }
     /// Load a user dictionary, comma-separated fields.
@@ -289,9 +287,9 @@ impl Dict {
     /// Optional feature for applications that need to use as little memory as possible without accessing disk constantly. "Undocumented". May be removed at any time for any reason.
     ///
     /// Does nothing if the prepare_full_matrix_cache has already been called.
-    pub fn prepare_fast_matrix_cache(&self, fast_left_edges : Vec<u16>, fast_right_edges : Vec<u16>)
+    pub fn prepare_fast_matrix_cache(&mut self, fast_left_edges : Vec<u16>, fast_right_edges : Vec<u16>)
     {
-        let mut matrix = self.matrix.borrow_mut();
+        let mut matrix = &mut self.matrix;
         
         if matrix.full_cache_enabled
         {
@@ -332,9 +330,9 @@ impl Dict {
     /// Load the entire connection matrix into memory. Suitable for small dictionaries, but is actually SLOWER than using prepare_fast_matrix_cache properly for extremely large dictionaries, like modern versions of unidic. "Undocumented".
     ///
     /// Overrides prepare_fast_matrix_cache if it has been called before.
-    pub fn prepare_full_matrix_cache(&self)
+    pub fn prepare_full_matrix_cache(&mut self)
     {
-        let mut matrix = self.matrix.borrow_mut();
+        let mut matrix = &mut self.matrix;
 
         matrix.full_cache_enabled = true;
         matrix.fast_edge_enabled = false;
@@ -354,7 +352,7 @@ impl Dict {
     }
     fn access_matrix(&self, left : u16, right : u16) -> i16
     {
-        let matrix = &self.matrix.borrow();
+        let matrix = &self.matrix;
         if matrix.full_cache_enabled
         {
             let loc = self.left_edges as usize * right as usize + left as usize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -727,10 +727,10 @@ mod tests {
         ret
     }
     
-    fn assert_parse(dict : &Dict, input : &'static str, truth : &'static str)
+    fn assert_parse(dict : &Dict, input : &str, truth : &str)
     {
         println!("testing parse...");
-        let result = parse(dict, &input.to_string()).unwrap();
+        let result = parse(dict, input).unwrap();
         
         for token in &result.0
         {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -804,13 +804,13 @@ mod tests {
         // This test will CERTAINLY fail if you don't have the same mecab dictionary.
         assert_parse(&dict,
           "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-          "Lorem|i|p|s|u|m|d|o|l|o|r|s|i|t|a|m|e|t|,|consectetur|adipiscing|elit|,|sed|do|eiusmod|tempor|incididunt|u|t|l|a|b|o|r|e|e|t|dolore|magna|aliqua|."
+          "Lorem|ipsum|dolor|s|i|t|a|m|e|t|,|consectetur|adipiscing|elit|,|sed|do|eiusmod|tempor|incididunt|u|t|l|a|b|o|r|e|e|t|dolore|magna|aliqua|."
         );
         
         // string that is known to trigger problems with at least one buggy pathfinding algorithm notmecab used before
         assert_parse(&dict,
           "だっでおら、こんな、こんなにっ！飛車角のこと、好きなんだでっ！！！！！！",
-          "だっ|で|おら|、|こんな|、|こんな|に|っ|！|飛車|角|の|こと|、|好き|な|ん|だ|で|っ|！|！|！|！|！|！"
+          "だっ|で|おら|、|こんな|、|こんな|に|っ|！|飛車|角|の|こと|、|好き|な|ん|だ|でっ|！|！|！|！|！|！"
         );
         
         // unknown character token stuff

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,23 +144,23 @@ impl LexerToken {
 
 #[derive(Clone)]
 #[derive(Debug)]
-pub struct ParserToken<'a> {
+pub struct ParserToken<'text, 'dict> {
     /// Exact sequence of characters with which this token appeared in the string that was parsed.
-    pub surface : String,
+    pub surface : &'text str,
     /// Description of this token's features.
     ///
     /// The feature string contains almost all useful information, including things like part of speech, spelling, pronunciation, etc.
     ///
     /// The exact format of the feature string is dictionary-specific.
-    pub feature : &'a str,
+    pub feature : &'dict str,
     /// Unique identifier of what specific lexeme realization this is, from the mecab dictionary. changes between dictionary versions.
     pub original_id : u32,
     /// Origin of token.
     pub kind : TokenType,
 }
 
-impl<'a> ParserToken<'a> {
-    fn build(surface : String, feature : &'a str, original_id : u32, kind : TokenType) -> ParserToken
+impl<'text, 'dict> ParserToken<'text, 'dict> {
+    fn build(surface : &'text str, feature : &'dict str, original_id : u32, kind : TokenType) -> Self
     {
         ParserToken
         { surface,
@@ -678,7 +678,7 @@ pub fn parse_to_lexertokens(dict : &Dict, text : &str) -> Option<(Vec<LexerToken
 /// Generates ParserTokens over the chosen path and returns a list of those ParserTokens and the cost the path took. Cost can be negative.
 /// 
 /// It's possible for multiple paths to tie for the lowest cost. It's not defined which path is returned in that case.
-pub fn parse<'a>(dict : &'a Dict, text : &str) -> Option<(Vec<ParserToken<'a>>, i64)>
+pub fn parse<'dict, 'text>(dict : &'dict Dict, text : &'text str) -> Option<(Vec<ParserToken<'text, 'dict>>, i64)>
 {
     let result = parse_to_lexertokens(dict, &text);
     // convert result into callee-usable vector of parse tokens, tupled together with cost
@@ -688,7 +688,7 @@ pub fn parse<'a>(dict : &'a Dict, text : &str) -> Option<(Vec<ParserToken<'a>>, 
         
         for token in result.0
         {
-            let surface : String = text[token.start..token.end].to_string();
+            let surface = &text[token.start..token.end];
             let feature = dict.read_feature_string(&token);
             lexeme_events.push(ParserToken::build(surface, feature, token.original_id, token.kind));
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -705,7 +705,10 @@ pub fn parse<'a>(dict : &'a Dict, text : &str) -> Option<(Vec<ParserToken<'a>>, 
 mod tests {
     use std::fs::File;
     use super::*;
-    
+
+    fn assert_implements_sync<T>() where T: Sync {}
+    fn assert_implements_send<T>() where T: Send {}
+
     // concatenate surface forms of parsertoken stream, with given comma between tokens
     fn tokenstream_to_string(stream : &Vec<ParserToken>, comma : &str) -> String
     {
@@ -749,6 +752,9 @@ mod tests {
     #[test]
     fn test_various()
     {
+        assert_implements_sync::<Dict>();
+        assert_implements_send::<Dict>();
+
         // you need to acquire a mecab dictionary and place these files here manually
         // These tests will probably fail if you use a different dictionary than me. That's normal. Different dicionaries parse differently.
         let sysdic = Blob::open("data/sys.dic").unwrap();

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -1,4 +1,0 @@
-pub (crate) fn codepoints(text : &str) -> Vec<char>
-{
-    text.chars().collect()
-}

--- a/src/unkchar.rs
+++ b/src/unkchar.rs
@@ -148,19 +148,19 @@ pub (crate) fn load_char_bin<T : Read>(file : &mut T) -> Result<UnkChar, &'stati
 
 #[cfg(test)]
 mod tests {
-    use std::fs::File;
-    use std::io::BufReader;
+    use std::io::Cursor;
     use super::*;
     use crate::dart;
-    
+    use crate::blob::Blob;
+
     #[test]
     fn test_unkchar_load()
     {
-        let unkdic = BufReader::new(File::open("data/unk.dic").unwrap());
-        let mut unkdef = BufReader::new(File::open("data/char.bin").unwrap());
-        
+        let unkdic = Blob::open("data/unk.dic").unwrap();
+        let unkdef = Blob::open("data/char.bin").unwrap();
+
         dart::load_mecab_dart_file(unkdic).unwrap();
-        load_char_bin(&mut unkdef).unwrap();
+        load_char_bin(&mut Cursor::new(unkdef)).unwrap();
     }
 }
 

--- a/src/userdict.rs
+++ b/src/userdict.rs
@@ -68,9 +68,9 @@ impl UserDict {
     {
         self.dict.get(find)
     }
-    pub (crate) fn feature_get(&self, offset : u32) -> String
+    pub (crate) fn feature_get(&self, offset : u32) -> &str
     {
-        self.features.get(offset as usize).cloned().unwrap_or_else(|| "".to_string())
+        self.features.get(offset as usize).map(|feature| feature.as_str()).unwrap_or("")
     }
 }
 


### PR DESCRIPTION
* I've updated the unit tests to align with the newest unidic. (The exact version and the md5sums are in the commit description.)
* I've added a new type - `Blob` - which is now used by `Dict::load` instead of raw streams. This allows the user to easily chose between loading their dictionary either from a file (through memory-mapped IO, using `Blob::open` or `Blob::from_file`), or from a `&'static [u8]` or `Vec<u8>` (through `Blob::new`), and it simplifies the implementation as now we can just dereference the `Blob` into an `&[u8]` and directly use that instead of mucking around with reading from a stream. (There are still a few places left which could use some refactoring in the future to directly access the data instead of using a `Cursor`.)
* I got rid of the internal automatic matrix cache. This is mostly unnecessary now as we can just do direct lookups on the matrix blob. I've left the the `prepare_fast_matrix_cache` and `prepare_full_matrix_cache` alone, however the `prepare_full_matrix_cache` should now probably be deleted as it's unlikely to be any faster. (No point in caching the whole matrix in a hash map if we already can access it in O(1) time.)
* I've removed the interior mutability from the `Dict`, so now it's possible to share the same `Dict` between multiple threads (hence now one can very easily parallelize the analysis and/or put a single `Dict` in a global `lazy_static` variable).
* I've made feature string extraction allocation-free - where previously it always allocated a new `String` now it simply returns an `&str`.
* I've made the construction of `ParserToken`s allocation-free.

Those changes cut down the runtime of my totally unscientific benchmark from 78 seconds to 56 seconds. (There is probably a lot more performance that could be squeezed here; for now I just want to make the library more usable for myself.)

This is a breaking change, so a semver bump will be necessary before publishing.