### PR TITLE
Update `hashbrown` and reduce dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,11 @@ doc = true
 
 [dependencies]
 byteorder = "1.2"
-hashbrown = "0.6"
+hashbrown = { version = "0.6", optional = true }
 memmap = "0.7"
+
+[features]
+default = ["hashbrown"]
 
 [profile.bench]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ readme = "readme.md"
 doc = true
 
 [dependencies]
-byteorder = "1.2"
 hashbrown = { version = "0.6", optional = true }
 memmap = "0.7"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ doc = true
 
 [dependencies]
 byteorder = "1.2"
-hashbrown = "0.5"
+hashbrown = "0.6"
 memmap = "0.7"
 
 [profile.bench]

--- a/src/dart.rs
+++ b/src/dart.rs
@@ -1,5 +1,5 @@
-use hashbrown::HashMap;
-use hashbrown::HashSet;
+use crate::HashMap;
+use crate::HashSet;
 
 use std::io::Cursor;
 use std::io::Read;

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,40 +1,47 @@
 use std::io::Read;
 
-extern crate byteorder;
-use byteorder::{LE, ReadBytesExt};
-
 pub (crate) fn read_i16<T : Read>(f : &mut T) -> Result<i16, &'static str>
 {
-    match f.read_i16::<LE>()
-    {
-        Ok(val) => Ok(val),
-        _ => Err("IO error")
-    }
+    read_u16(f).map(|val| val as i16)
 }
 pub (crate) fn read_u16<T : Read>(f : &mut T) -> Result<u16, &'static str>
 {
-    match f.read_u16::<LE>()
+    let mut buffer = [0; 2];
+    match f.read_exact(&mut buffer)
     {
-        Ok(val) => Ok(val),
+        Ok(()) => Ok(u16::from_le_bytes(buffer)),
         _ => Err("IO error")
     }
 }
 pub (crate) fn read_u32<T : Read>(f : &mut T) -> Result<u32, &'static str>
 {
-    match f.read_u32::<LE>()
+    let mut buffer = [0; 4];
+    match f.read_exact(&mut buffer)
     {
-        Ok(val) => Ok(val),
+        Ok(()) => Ok(u32::from_le_bytes(buffer)),
         _ => Err("IO error")
     }
 }
 
+unsafe fn as_byte_slice_mut<T>(slice : &mut [T]) -> &mut [u8]
+{
+    std::slice::from_raw_parts_mut(
+        slice.as_mut_ptr() as *mut u8,
+        slice.len() * std::mem::size_of::<T>()
+    )
+}
+
 pub (crate) fn read_i16_buffer<T : Read>(f : &mut T, dst : &mut [i16]) -> Result<(), &'static str>
 {
-    match f.read_i16_into::<LE>(dst)
+    let dst_b = unsafe { as_byte_slice_mut(dst) };
+    f.read_exact(dst_b).map_err(|_| "IO error")?;
+
+    for val in dst.iter_mut()
     {
-        Ok(_) => Ok(()),
-        _ => Err("IO error")
+        *val = i16::from_le(*val);
     }
+
+    Ok(())
 }
 
 fn trim_at_null(mystr : &[u8]) -> &[u8]
@@ -107,6 +114,14 @@ mod tests {
     {
         let vec = vec![0x20u8, 0x00u8, 0x20u8];
         assert_eq!(super::read_str_buffer(&vec), Ok(" ".to_string()));
+    }
+    #[test]
+    fn read_i16_buffer()
+    {
+        let input = &[0x12, 0x34, 0x56, 0x78];
+        let mut out = [0i16, 2];
+        super::read_i16_buffer(&mut &input[..], &mut out).unwrap();
+        assert_eq!(out, [0x3412, 0x7856]);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,16 @@ use std::ops::Deref;
 
 use std::str;
 
+#[cfg(not(feature = "hashbrown"))]
+pub(crate) use std::collections::HashMap;
+#[cfg(not(feature = "hashbrown"))]
+pub(crate) use std::collections::HashSet;
+
+#[cfg(feature = "hashbrown")]
+pub(crate) use hashbrown::HashMap;
+#[cfg(feature = "hashbrown")]
+pub(crate) use hashbrown::HashSet;
+
 mod blob;
 mod file;
 mod dart;

--- a/src/unkchar.rs
+++ b/src/unkchar.rs
@@ -1,4 +1,4 @@
-use hashbrown::HashMap;
+use crate::HashMap;
 
 use std::io::Read;
 

--- a/src/userdict.rs
+++ b/src/userdict.rs
@@ -1,8 +1,8 @@
 use std::io::BufRead;
 use std::io::Read;
 
-use hashbrown::HashMap;
-use hashbrown::HashSet;
+use crate::HashMap;
+use crate::HashSet;
 
 use crate::FormatToken;
 


### PR DESCRIPTION
I've updated the `hashbrown` dependency and made it optional (I've left it turned on by default), and while I was at it I've also got rid of the `byteorder` dependency since we don't really make a huge use of it anyway.