### PR TITLE
Make it possible to cache memory between invocations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -740,18 +740,6 @@ fn generate_potential_tokens<'a>(dict : &'a Dict, text : &str, output : &mut Vec
     }
 }
 
-/// Tokenizes a char slice by creating a lattice of possible tokens over it and finding the lowest-cost path over that lattice. Returns a list of LexerTokens and the cost of the tokenization.
-///
-/// The dictionary defines what tokens exist, how they appear in the string, their costs, and the costs of their possible connections.
-///
-/// Returns a vector listing the LexerTokens on the chosen path and the cost the path took. Cost can be negative.
-///
-/// It's possible for multiple paths to tie for the lowest cost. It's not defined which path is returned in that case.
-pub fn parse_to_lexertokens(dict : &Dict, text : &str) -> Option<(Vec<LexerToken>, i64)>
-{
-    dict.tokenize(text).ok()
-}
-
 /// Tokenizes a string by creating a lattice of possible tokens over it and finding the lowest-cost path over that lattice. Returns a list of ParserToken and the cost of the tokenization.
 ///
 /// The dictionary defines what tokens exist, how they appear in the string, their costs, and the costs of their possible connections.
@@ -761,9 +749,9 @@ pub fn parse_to_lexertokens(dict : &Dict, text : &str) -> Option<(Vec<LexerToken
 /// It's possible for multiple paths to tie for the lowest cost. It's not defined which path is returned in that case.
 pub fn parse<'dict, 'text>(dict : &'dict Dict, text : &'text str) -> Option<(Vec<ParserToken<'text, 'dict>>, i64)>
 {
-    let result = parse_to_lexertokens(dict, &text);
+    let result = dict.tokenize(&text);
     // convert result into callee-usable vector of parse tokens, tupled together with cost
-    if let Some(result) = result
+    if let Ok(result) = result
     {
         let mut lexeme_events : Vec<ParserToken> = Vec::with_capacity(result.0.len());
         

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,28 @@ pub struct LexerToken {
     pub feature_offset : u32,
 }
 
+impl LexerToken {
+    /// Returns the text to which this token corresponds to in the original text.
+    ///
+    /// The `whole_text` is the original string for which you've
+    /// called [`Dict::tokenize`] or [`Dict::tokenize_with_cache`].
+    pub fn get_text<'a>(&self, whole_text : &'a str) -> &'a str
+    {
+        &whole_text[self.range.clone()]
+    }
+
+    /// Returns a feature string corresponding to this token.
+    ///
+    /// Feature strings are dictionary-specific so unfortunately
+    /// you need to parse them yourself. They usually contain
+    /// things like the exact part-of-speech this token represents,
+    /// its reading, whenever it's conjugated or not, etc.
+    pub fn get_feature<'a>(&self, dict : &'a Dict) -> &'a str
+    {
+        dict.read_feature_string(self)
+    }
+}
+
 #[derive(Clone)]
 #[derive(Debug)]
 pub struct ParserToken<'text, 'dict> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,11 +96,9 @@ pub struct LexerToken {
     pub cost : i64,
     /// Cost updated to include right-edge connection cost after parsing.
     pub real_cost : i64, 
-    
-    /// Location, in bytes, of the surface of this LexerToken in the string it was parsed from.
-    pub start : usize, 
-    /// Corresponding ending location, in bytes. Exclusive. (i.e. when start+1 == end, the LexerToken's surface is one byte long)
-    pub end   : usize,
+
+    /// The range, in bytes, to which this token corresponds to in the original text.
+    pub range : Range<usize>,
 
     /// Origin of token. BOS and UNK are virtual origins ("beginning/ending-of-string" and "unknown", respectively). Normal means it came from the mecab dictionary.
     ///
@@ -557,8 +555,7 @@ impl<'a> From<&'a Token<'a>> for LexerToken
             pos : token.pos,
             cost : token.cost,
             real_cost : 0,
-            start : token.range.start,
-            end : token.range.end,
+            range : token.range.clone(),
             kind : token.kind,
             original_id : token.original_id,
             feature_offset : token.feature_offset
@@ -750,7 +747,7 @@ pub fn parse<'dict, 'text>(dict : &'dict Dict, text : &'text str) -> Option<(Vec
         
         for token in result.0
         {
-            let surface = &text[token.start..token.end];
+            let surface = &text[token.range.clone()];
             let feature = dict.read_feature_string(&token);
             lexeme_events.push(ParserToken::build(surface, feature, token.original_id, token.kind));
         }


### PR DESCRIPTION
I've added `Dict::tokenize` which is basically `parse_to_lexertokens` but allows you to 1) pass a `Cache` object which when used across multiple invocations will let the code reuse the previously made internal allocations, and 2) pushes the tokens to an existing vector instead of returning a new one. This makes it possible to run the whole thing without making any allocations in the average case.

This speeds up one of my benchmarks by 30% when there already exists pressure on the allocator (basically, when something else is already running in the background and hammering the allocator), and speeds it up by 20% if there isn't any allocator pressure (when only the benchmark code itself is running).

I've left `parse_to_lexertokens` for backwards compatibility, however I've slapped an `#[deprecated]` on it. I've left `parse` alone, though personally I'd just remove it altogether - after all it's trivial to just call `read_feature_string` yourself. (It's up to you though.)