### PR TITLE
Store hashes instead of strings for checking whenever a longer token exists

### DIFF
--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -1,0 +1,20 @@
+pub struct Hasher(u64);
+
+// This is basically FNV, just extended to do 4 bytes at a time.
+impl Hasher {
+    pub fn new() -> Self
+    {
+        Hasher(0xcbf29ce484222325)
+    }
+
+    pub fn write_u32(&mut self, value : u32)
+    {
+        let value = value as u64;
+        self.0 = (self.0 ^ value).wrapping_mul(0x100000001b3);
+    }
+
+    pub fn finish(&self) -> u64
+    {
+        self.0
+    }
+}


### PR DESCRIPTION
Another small performance improvement.

* One big string benchmark: 30% faster
* Many small strings benchmark: 10% faster
* At least 9MB less memory used.

Basically instead of full strings only hashes are now stored in `DartDict::contains_longer`. There is no real point in storing the full strings there since this is only used to check whenever a longer match can exist, so even *if* there are false positives due to hash collisions at worst we'll just burn a little more CPU.